### PR TITLE
Data type handling, Multiple Result Set

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SYNOPSYS
 	var db = new odbc.Database();
 	db.open("DRIVER={FreeTDS};SERVER=host;UID=user;PWD=password;DATABASE=dbname", function(err)
 	{
-		db.query("select * from table", function(err, rows)
+		db.query("select * from table", function(err, rows, moreResultSets)
 		{
 			sys.debug(sys.inspect(rows));
 			db.close(function(){});

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Installation
 - Make sure you have unixODBC installed and the drivers configured.
 - node-waf configure build
 
+TIPS
+----
+
+- If you are using the FreeTDS ODBC driver and you have column names longer than 30 characters, you should add "TDS_Version=7.0" to your connection string to retrive the full column name.
+  Example: "DRIVER={FreeTDS};SERVER=host;UID=user;PWD=password;DATABASE=dbname;TDS_Version=7.0"
+
+
 BUGS
 ----
 

--- a/odbc.js
+++ b/odbc.js
@@ -30,7 +30,7 @@ var Database = exports.Database = function () {
     db.addListener("result", function () {
         //process.assert(db.currentQuery).ok();
         require('assert').ok(db.currentQuery);
-	
+        
         var callback = db.currentQuery[1];
         var args = Array.prototype.slice.call(db.currentQuery[2]);
         args.shift();
@@ -41,11 +41,11 @@ var Database = exports.Database = function () {
             arguments[0].query = db.currentQuery[0];
         }
         
+        //check to see if this is the last result set returned
+        if (!arguments[2]) {
+            db.currentQuery = null;
+        }
         
-console.log('result: arguments[2]: ' + arguments[2]);
-	
-	
-        db.currentQuery = null;
         if (callback) {
             var newArgs = Array.prototype.slice.call(arguments);
 

--- a/odbc.js
+++ b/odbc.js
@@ -28,7 +28,9 @@ var Database = exports.Database = function () {
     });
 
     db.addListener("result", function () {
-        process.assert(db.currentQuery);
+        //process.assert(db.currentQuery).ok();
+        require('assert').ok(db.currentQuery);
+	
             var callback = db.currentQuery[1];
         var args = Array.prototype.slice.call(db.currentQuery[2]);
         args.shift();

--- a/odbc.js
+++ b/odbc.js
@@ -31,7 +31,7 @@ var Database = exports.Database = function () {
         //process.assert(db.currentQuery).ok();
         require('assert').ok(db.currentQuery);
 	
-            var callback = db.currentQuery[1];
+        var callback = db.currentQuery[1];
         var args = Array.prototype.slice.call(db.currentQuery[2]);
         args.shift();
         args.shift();
@@ -40,7 +40,11 @@ var Database = exports.Database = function () {
         {
             arguments[0].query = db.currentQuery[0];
         }
-
+        
+        
+console.log('result: arguments[2]: ' + arguments[2]);
+	
+	
         db.currentQuery = null;
         if (callback) {
             var newArgs = Array.prototype.slice.call(arguments);

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -1,17 +1,17 @@
 /*
-	Copyright (c) 2010, Lee Smith<notwink@gmail.com>
+  Copyright (c) 2010, Lee Smith<notwink@gmail.com>
 
-	Permission to use, copy, modify, and/or distribute this software for any
-	purpose with or without fee is hereby granted, provided that the above
-	copyright notice and this permission notice appear in all copies.
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
 
-	THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-	WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-	MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-	ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-	WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-	ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-	OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
 #include <string.h>
@@ -27,385 +27,385 @@ using namespace v8;
 using namespace node;
 
 typedef struct {
-	unsigned char *name;
-	unsigned int len;
+  unsigned char *name;
+  unsigned int len;
 } ColumnLabel;
 
 
 void Database::Init(v8::Handle<Object> target) {
-	HandleScope scope;
+  HandleScope scope;
 
-	Local<FunctionTemplate> t = FunctionTemplate::New(New);
+  Local<FunctionTemplate> t = FunctionTemplate::New(New);
 
-	constructor_template = Persistent<FunctionTemplate>::New(t);
-	constructor_template->Inherit(EventEmitter::constructor_template);
-	constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
-	constructor_template->SetClassName(String::NewSymbol("Database"));
+  constructor_template = Persistent<FunctionTemplate>::New(t);
+  constructor_template->Inherit(EventEmitter::constructor_template);
+  constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
+  constructor_template->SetClassName(String::NewSymbol("Database"));
 
-	NODE_SET_PROTOTYPE_METHOD(constructor_template, "open", Open);
-	NODE_SET_PROTOTYPE_METHOD(constructor_template, "close", Close);
-	NODE_SET_PROTOTYPE_METHOD(constructor_template, "dispatchQuery", Query);
+  NODE_SET_PROTOTYPE_METHOD(constructor_template, "open", Open);
+  NODE_SET_PROTOTYPE_METHOD(constructor_template, "close", Close);
+  NODE_SET_PROTOTYPE_METHOD(constructor_template, "dispatchQuery", Query);
 
-	target->Set(v8::String::NewSymbol("Database"), constructor_template->GetFunction());
+  target->Set(v8::String::NewSymbol("Database"), constructor_template->GetFunction());
 }
 
 Handle<Value> Database::New(const Arguments& args) {
-	HandleScope scope;
-	Database* dbo = new Database();
-	dbo->Wrap(args.This());
-	return args.This();
+  HandleScope scope;
+  Database* dbo = new Database();
+  dbo->Wrap(args.This());
+  return args.This();
 }
 
 int Database::EIO_AfterOpen(eio_req *req) {
-	ev_unref(EV_DEFAULT_UC);
-	HandleScope scope;
-	struct open_request *open_req = (struct open_request *)(req->data);
+  ev_unref(EV_DEFAULT_UC);
+  HandleScope scope;
+  struct open_request *open_req = (struct open_request *)(req->data);
 
-	Local<Value> argv[1];
-	bool err = false;
-	if (req->result) {
-		err = true;
-		argv[0] = Exception::Error(String::New("Error opening database"));
-	}
+  Local<Value> argv[1];
+  bool err = false;
+  if (req->result) {
+    err = true;
+    argv[0] = Exception::Error(String::New("Error opening database"));
+  }
 
-	TryCatch try_catch;
+  TryCatch try_catch;
 
-	open_req->dbo->Unref();
-	open_req->cb->Call(Context::GetCurrent()->Global(), err ? 1 : 0, argv);
+  open_req->dbo->Unref();
+  open_req->cb->Call(Context::GetCurrent()->Global(), err ? 1 : 0, argv);
 
-	if (try_catch.HasCaught()) {
-		FatalException(try_catch);
-	}
+  if (try_catch.HasCaught()) {
+    FatalException(try_catch);
+  }
 
-	open_req->dbo->Emit(String::New("ready"), 0, NULL);
-	open_req->cb.Dispose();
+  open_req->dbo->Emit(String::New("ready"), 0, NULL);
+  open_req->cb.Dispose();
 
-	free(open_req);
-	scope.Close(Undefined());
-	return 0;
+  free(open_req);
+  scope.Close(Undefined());
+  return 0;
 }
 
 int Database::EIO_Open(eio_req *req) {
-	struct open_request *open_req = (struct open_request *)(req->data);
-	Database *self = open_req->dbo->self();
+  struct open_request *open_req = (struct open_request *)(req->data);
+  Database *self = open_req->dbo->self();
 
-	int ret = SQLAllocEnv( &self->m_hEnv );
-	if( ret == SQL_SUCCESS ) {
-		ret = SQLAllocConnect( self->m_hEnv,&self->m_hDBC );
-		if( ret == SQL_SUCCESS ) {
-			SQLSetConnectOption( self->m_hDBC,SQL_LOGIN_TIMEOUT,5 );
-			char connstr[1024];
-			ret = SQLDriverConnect(self->m_hDBC,NULL,(SQLCHAR*)open_req->connection,strlen(open_req->connection),(SQLCHAR*)connstr,1024,NULL,SQL_DRIVER_NOPROMPT);
+  int ret = SQLAllocEnv( &self->m_hEnv );
+  if( ret == SQL_SUCCESS ) {
+    ret = SQLAllocConnect( self->m_hEnv,&self->m_hDBC );
+    if( ret == SQL_SUCCESS ) {
+      SQLSetConnectOption( self->m_hDBC,SQL_LOGIN_TIMEOUT,5 );
+      char connstr[1024];
+      ret = SQLDriverConnect(self->m_hDBC,NULL,(SQLCHAR*)open_req->connection,strlen(open_req->connection),(SQLCHAR*)connstr,1024,NULL,SQL_DRIVER_NOPROMPT);
 
-			if( ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO )
-				{
-					ret = SQLAllocStmt( self->m_hDBC,&self->m_hStmt );
-					if (ret != SQL_SUCCESS) printf("not connected\n");
-				}
-			else
-				{
-					self->printError("SQLDriverConnect", self->m_hDBC, SQL_HANDLE_DBC);
-				}
-		}
-	}
-	req->result = ret;
-	return 0;
+      if( ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO )
+        {
+          ret = SQLAllocStmt( self->m_hDBC,&self->m_hStmt );
+          if (ret != SQL_SUCCESS) printf("not connected\n");
+        }
+      else
+        {
+          self->printError("SQLDriverConnect", self->m_hDBC, SQL_HANDLE_DBC);
+        }
+    }
+  }
+  req->result = ret;
+  return 0;
 }
 
 Handle<Value> Database::Open(const Arguments& args) {
-	HandleScope scope;
+  HandleScope scope;
 
-	REQ_STR_ARG(0, connection);
-	REQ_FUN_ARG(1, cb);
+  REQ_STR_ARG(0, connection);
+  REQ_FUN_ARG(1, cb);
 
-	Database* dbo = ObjectWrap::Unwrap<Database>(args.This());
+  Database* dbo = ObjectWrap::Unwrap<Database>(args.This());
 
-	struct open_request *open_req = (struct open_request *)
-		calloc(1, sizeof(struct open_request) + connection.length());
+  struct open_request *open_req = (struct open_request *)
+    calloc(1, sizeof(struct open_request) + connection.length());
 
-	if (!open_req) {
-		V8::LowMemoryNotification();
-		return ThrowException(Exception::Error(String::New("Could not allocate enough memory")));
-	}
+  if (!open_req) {
+    V8::LowMemoryNotification();
+    return ThrowException(Exception::Error(String::New("Could not allocate enough memory")));
+  }
 
-	strcpy(open_req->connection, *connection);
-	open_req->cb = Persistent<Function>::New(cb);
-	open_req->dbo = dbo;
+  strcpy(open_req->connection, *connection);
+  open_req->cb = Persistent<Function>::New(cb);
+  open_req->dbo = dbo;
 
-	eio_custom(EIO_Open, EIO_PRI_DEFAULT, EIO_AfterOpen, open_req);
+  eio_custom(EIO_Open, EIO_PRI_DEFAULT, EIO_AfterOpen, open_req);
 
-	ev_ref(EV_DEFAULT_UC);
-	dbo->Ref();
-	scope.Close(Undefined());
-	return Undefined();
+  ev_ref(EV_DEFAULT_UC);
+  dbo->Ref();
+  scope.Close(Undefined());
+  return Undefined();
 }
 
 int Database::EIO_AfterClose(eio_req *req) {
-	ev_unref(EV_DEFAULT_UC);
+  ev_unref(EV_DEFAULT_UC);
 
-	HandleScope scope;
+  HandleScope scope;
 
-	struct close_request *close_req = (struct close_request *)(req->data);
+  struct close_request *close_req = (struct close_request *)(req->data);
 
-	Local<Value> argv[1];
-	bool err = false;
-	if (req->result) {
-		err = true;
-		argv[0] = Exception::Error(String::New("Error closing database"));
-	}
+  Local<Value> argv[1];
+  bool err = false;
+  if (req->result) {
+    err = true;
+    argv[0] = Exception::Error(String::New("Error closing database"));
+  }
 
-	TryCatch try_catch;
+  TryCatch try_catch;
 
-	close_req->dbo->Unref();
-	close_req->cb->Call(Context::GetCurrent()->Global(), err ? 1 : 0, argv);
+  close_req->dbo->Unref();
+  close_req->cb->Call(Context::GetCurrent()->Global(), err ? 1 : 0, argv);
 
-	if (try_catch.HasCaught()) {
-		FatalException(try_catch);
-	}
+  if (try_catch.HasCaught()) {
+    FatalException(try_catch);
+  }
 
-	close_req->cb.Dispose();
+  close_req->cb.Dispose();
 
-	free(close_req);
-	scope.Close(Undefined());
-	return 0;
+  free(close_req);
+  scope.Close(Undefined());
+  return 0;
 }
 
 int Database::EIO_Close(eio_req *req) {
-	struct close_request *close_req = (struct close_request *)(req->data);
-	Database* dbo = close_req->dbo;
-	SQLDisconnect(dbo->m_hDBC);
-	SQLFreeHandle(SQL_HANDLE_ENV, dbo->m_hEnv);
-	SQLFreeHandle(SQL_HANDLE_DBC, dbo->m_hDBC);
-	return 0;
+  struct close_request *close_req = (struct close_request *)(req->data);
+  Database* dbo = close_req->dbo;
+  SQLDisconnect(dbo->m_hDBC);
+  SQLFreeHandle(SQL_HANDLE_ENV, dbo->m_hEnv);
+  SQLFreeHandle(SQL_HANDLE_DBC, dbo->m_hDBC);
+  return 0;
 }
 
 Handle<Value> Database::Close(const Arguments& args) {
-	HandleScope scope;
+  HandleScope scope;
 
-	REQ_FUN_ARG(0, cb);
+  REQ_FUN_ARG(0, cb);
 
-	Database* dbo = ObjectWrap::Unwrap<Database>(args.This());
+  Database* dbo = ObjectWrap::Unwrap<Database>(args.This());
 
-	struct close_request *close_req = (struct close_request *)
-		calloc(1, sizeof(struct close_request));
+  struct close_request *close_req = (struct close_request *)
+    calloc(1, sizeof(struct close_request));
 
-	if (!close_req) {
-		V8::LowMemoryNotification();
-		return ThrowException(Exception::Error(
-																					 String::New("Could not allocate enough memory")));
-	}
+  if (!close_req) {
+    V8::LowMemoryNotification();
+    return ThrowException(Exception::Error(
+                                           String::New("Could not allocate enough memory")));
+  }
 
-	close_req->cb = Persistent<Function>::New(cb);
-	close_req->dbo = dbo;
+  close_req->cb = Persistent<Function>::New(cb);
+  close_req->dbo = dbo;
 
-	eio_custom(EIO_Close, EIO_PRI_DEFAULT, EIO_AfterClose, close_req);
+  eio_custom(EIO_Close, EIO_PRI_DEFAULT, EIO_AfterClose, close_req);
 
-	ev_ref(EV_DEFAULT_UC);
-	dbo->Ref();
-	scope.Close(Undefined());
-	return Undefined();
+  ev_ref(EV_DEFAULT_UC);
+  dbo->Ref();
+  scope.Close(Undefined());
+  return Undefined();
 }
 
 int Database::EIO_AfterQuery(eio_req *req) {
-	ev_unref(EV_DEFAULT_UC);
-	struct query_request *prep_req = (struct query_request *)(req->data);
-	HandleScope scope;
+  ev_unref(EV_DEFAULT_UC);
+  struct query_request *prep_req = (struct query_request *)(req->data);
+  HandleScope scope;
 
-	// get column data
-	short colcount;
-	SQLSMALLINT buflen;
-	SQLRETURN ret;
-	SQLNumResultCols(prep_req->dbo->m_hStmt, &colcount);
+  // get column data
+  short colcount;
+  SQLSMALLINT buflen;
+  SQLRETURN ret;
+  SQLNumResultCols(prep_req->dbo->m_hStmt, &colcount);
 
-	SQLLEN nColumnType;
-	SQLLEN *aColumnTypes = (SQLLEN *)malloc(sizeof(SQLLEN) * colcount);
-		
-	ColumnLabel *labels = new ColumnLabel[colcount];
+  SQLLEN nColumnType;
+  SQLLEN *aColumnTypes = (SQLLEN *)malloc(sizeof(SQLLEN) * colcount);
+    
+  ColumnLabel *labels = new ColumnLabel[colcount];
 
-	// retrieve and store column names to build the row object
-	for(int i = 0; i < colcount; i++)
-	{
-		labels[i].name = new unsigned char[MAX_FIELD_SIZE];
-		memset(labels[i].name, 0, MAX_FIELD_SIZE);
-		ret = SQLColAttribute(prep_req->dbo->m_hStmt, (SQLUSMALLINT)i+1, SQL_DESC_LABEL, labels[i].name, (SQLSMALLINT)MAX_FIELD_SIZE, (SQLSMALLINT *)&buflen, NULL);
-		labels[i].len = buflen;
-		
-		//get the column type
-		ret = SQLColAttribute( prep_req->dbo->m_hStmt, (SQLUSMALLINT)i+1, SQL_COLUMN_TYPE, NULL, NULL, NULL, &aColumnTypes[ i ] );
-		
-	}
+  // retrieve and store column names to build the row object
+  for(int i = 0; i < colcount; i++)
+  {
+    labels[i].name = new unsigned char[MAX_FIELD_SIZE];
+    memset(labels[i].name, 0, MAX_FIELD_SIZE);
+    ret = SQLColAttribute(prep_req->dbo->m_hStmt, (SQLUSMALLINT)i+1, SQL_DESC_LABEL, labels[i].name, (SQLSMALLINT)MAX_FIELD_SIZE, (SQLSMALLINT *)&buflen, NULL);
+    labels[i].len = buflen;
+    
+    //get the column type
+    ret = SQLColAttribute( prep_req->dbo->m_hStmt, (SQLUSMALLINT)i+1, SQL_COLUMN_TYPE, NULL, NULL, NULL, &aColumnTypes[ i ] );
+    
+  }
 
-	// i dont think odbc will tell how many rows are returned, loop until out...
-	Local<Array> rows = Array::New();
-	int count = 0;
-	while(true)
-	{
-		Local<Object> tuple = Object::New();
-		ret = SQLFetch(prep_req->dbo->m_hStmt);
-		if(ret) break; // error :|
+  // i dont think odbc will tell how many rows are returned, loop until out...
+  Local<Array> rows = Array::New();
+  int count = 0;
+  while(true)
+  {
+    Local<Object> tuple = Object::New();
+    ret = SQLFetch(prep_req->dbo->m_hStmt);
+    if(ret) break; // error :|
 
-		for(int i = 0; i < colcount; i++)
-		{
-			SQLLEN len;
-			
-			//get the column type;
-			nColumnType = aColumnTypes[i];
-			
-			// SQLGetData can supposedly return multiple chunks, need to do this to retrieve large fields
+    for(int i = 0; i < colcount; i++)
+    {
+      SQLLEN len;
+      
+      //get the column type;
+      nColumnType = aColumnTypes[i];
+      
+      // SQLGetData can supposedly return multiple chunks, need to do this to retrieve large fields
 
-			char buf[MAX_FIELD_SIZE];
-			memset(buf,0,MAX_FIELD_SIZE);
-			int ret = SQLGetData(prep_req->dbo->m_hStmt, i+1, SQL_CHAR, (char *) buf, MAX_FIELD_SIZE-1, (SQLLEN *) &len);
+      char buf[MAX_FIELD_SIZE];
+      memset(buf,0,MAX_FIELD_SIZE);
+      int ret = SQLGetData(prep_req->dbo->m_hStmt, i+1, SQL_CHAR, (char *) buf, MAX_FIELD_SIZE-1, (SQLLEN *) &len);
 
-			if(ret == SQL_NULL_DATA || len < 0)
-			{
-				tuple->Set(String::New((const char *)labels[i].name), Null());
-			}
-			else
-			{ 
-				switch (nColumnType) {
-					case SQL_NUMERIC :
-						tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
-						break;
-					case SQL_DECIMAL :
-						tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
-						break;
-					case SQL_INTEGER :
-						tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
-						break;
-					case SQL_SMALLINT :
-						tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
-						break;
-					case SQL_FLOAT :
-						tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
-						break;
-					case SQL_REAL :
-						tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
-						break;
-					case SQL_DOUBLE :
-						tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
-						break;
-					default :
-						tuple->Set(String::New((const char *)labels[i].name), String::New(buf));
-						break;
-				}
-			}
-		}
-		rows->Set(Integer::New(count), tuple);
-		count++;
-	}
+      if(ret == SQL_NULL_DATA || len < 0)
+      {
+        tuple->Set(String::New((const char *)labels[i].name), Null());
+      }
+      else
+      { 
+        switch (nColumnType) {
+          case SQL_NUMERIC :
+            tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
+            break;
+          case SQL_DECIMAL :
+            tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
+            break;
+          case SQL_INTEGER :
+            tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
+            break;
+          case SQL_SMALLINT :
+            tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
+            break;
+          case SQL_FLOAT :
+            tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
+            break;
+          case SQL_REAL :
+            tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
+            break;
+          case SQL_DOUBLE :
+            tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
+            break;
+          default :
+            tuple->Set(String::New((const char *)labels[i].name), String::New(buf));
+            break;
+        }
+      }
+    }
+    rows->Set(Integer::New(count), tuple);
+    count++;
+  }
 
-	for(int i = 0; i < colcount; i++)
-	{
-		delete [] labels[i].name;
-	}
-	
-	delete [] labels;
+  for(int i = 0; i < colcount; i++)
+  {
+    delete [] labels[i].name;
+  }
+  
+  delete [] labels;
 
-	TryCatch try_catch;
+  TryCatch try_catch;
 
-	prep_req->dbo->Unref();
+  prep_req->dbo->Unref();
 
-	if (try_catch.HasCaught()) {
-		FatalException(try_catch);
-	}
+  if (try_catch.HasCaught()) {
+    FatalException(try_catch);
+  }
 
-	SQLFreeStmt(prep_req->dbo->m_hStmt,NULL);
-	SQLAllocStmt(prep_req->dbo->m_hDBC,&prep_req->dbo->m_hStmt );
+  SQLFreeStmt(prep_req->dbo->m_hStmt,NULL);
+  SQLAllocStmt(prep_req->dbo->m_hDBC,&prep_req->dbo->m_hStmt );
 
 
-	Local<Value> args[2];
-	args[0] = Local<Value>::New(Null());
-	args[1] = rows;
+  Local<Value> args[2];
+  args[0] = Local<Value>::New(Null());
+  args[1] = rows;
 
-	prep_req->dbo->Emit(String::New("result"), 2, args);
+  prep_req->dbo->Emit(String::New("result"), 2, args);
 
-	free(aColumnTypes);
-	free(prep_req);
-	scope.Close(Undefined());
-	
-	
-	return 0;
+  free(aColumnTypes);
+  free(prep_req);
+  scope.Close(Undefined());
+  
+  
+  return 0;
 }
 
 int Database::EIO_Query(eio_req *req) {
-	struct query_request *prep_req = (struct query_request *)(req->data);
+  struct query_request *prep_req = (struct query_request *)(req->data);
 
 
-	if(prep_req->dbo->m_hStmt)
-		{
-			SQLFreeStmt(prep_req->dbo->m_hStmt,NULL);
-			SQLAllocStmt(prep_req->dbo->m_hDBC,&prep_req->dbo->m_hStmt );
-		}
+  if(prep_req->dbo->m_hStmt)
+    {
+      SQLFreeStmt(prep_req->dbo->m_hStmt,NULL);
+      SQLAllocStmt(prep_req->dbo->m_hDBC,&prep_req->dbo->m_hStmt );
+    }
 
-	SQLRETURN ret = SQLExecDirect( prep_req->dbo->m_hStmt,(SQLCHAR *)prep_req->sql, strlen(prep_req->sql) );
-	if(ret != 0)
-		{
-			char buf[512];
-			char sqlstate[128];
-			SQLError(prep_req->dbo->m_hEnv, prep_req->dbo->m_hDBC, prep_req->dbo->m_hStmt,(SQLCHAR *)sqlstate,NULL,(SQLCHAR *)buf, sizeof(buf), NULL);
-		}
+  SQLRETURN ret = SQLExecDirect( prep_req->dbo->m_hStmt,(SQLCHAR *)prep_req->sql, strlen(prep_req->sql) );
+  if(ret != 0)
+    {
+      char buf[512];
+      char sqlstate[128];
+      SQLError(prep_req->dbo->m_hEnv, prep_req->dbo->m_hDBC, prep_req->dbo->m_hStmt,(SQLCHAR *)sqlstate,NULL,(SQLCHAR *)buf, sizeof(buf), NULL);
+    }
 
-	req->result = ret;
+  req->result = ret;
 
-	return 0;
+  return 0;
 }
 
 Handle<Value> Database::Query(const Arguments& args) {
-	HandleScope scope;
+  HandleScope scope;
 
-	REQ_STR_ARG(0, sql);
-	//REQ_FUN_ARG(1, cb);
+  REQ_STR_ARG(0, sql);
+  //REQ_FUN_ARG(1, cb);
 
-	Database* dbo = ObjectWrap::Unwrap<Database>(args.This());
+  Database* dbo = ObjectWrap::Unwrap<Database>(args.This());
 
-	struct query_request *prep_req = (struct query_request *)
-		calloc(1, sizeof(struct query_request) + sql.length());
+  struct query_request *prep_req = (struct query_request *)
+    calloc(1, sizeof(struct query_request) + sql.length());
 
-	if (!prep_req) {
-		V8::LowMemoryNotification();
-		return ThrowException(Exception::Error(String::New("Could not allocate enough memory")));
-	}
+  if (!prep_req) {
+    V8::LowMemoryNotification();
+    return ThrowException(Exception::Error(String::New("Could not allocate enough memory")));
+  }
 
-	strcpy(prep_req->sql, *sql);
+  strcpy(prep_req->sql, *sql);
 
-	prep_req->dbo = dbo;
+  prep_req->dbo = dbo;
 
-	eio_custom(EIO_Query, EIO_PRI_DEFAULT, EIO_AfterQuery, prep_req);
+  eio_custom(EIO_Query, EIO_PRI_DEFAULT, EIO_AfterQuery, prep_req);
 
-	ev_ref(EV_DEFAULT_UC);
-	dbo->Ref();
-	scope.Close(Undefined());
-	return Undefined();
+  ev_ref(EV_DEFAULT_UC);
+  dbo->Ref();
+  scope.Close(Undefined());
+  return Undefined();
 }
 
 void Database::printError(const char *fn, SQLHANDLE handle, SQLSMALLINT type)
 {
-	SQLINTEGER i = 0;
-	SQLINTEGER native;
-	SQLCHAR state[ 7 ];
-	SQLCHAR text[256];
-	SQLSMALLINT len;
-	SQLRETURN ret;
+  SQLINTEGER i = 0;
+  SQLINTEGER native;
+  SQLCHAR state[ 7 ];
+  SQLCHAR text[256];
+  SQLSMALLINT len;
+  SQLRETURN ret;
 
-	fprintf(stderr,
-		"\n"
-		"The driver reported the following diagnostics whilst running "
-		"%s\n\n",
-		fn
-	);
+  fprintf(stderr,
+    "\n"
+    "The driver reported the following diagnostics whilst running "
+    "%s\n\n",
+    fn
+  );
 
-	do {
-		ret = SQLGetDiagRec(type, handle, ++i, state, &native, text, sizeof(text), &len );
-		if (SQL_SUCCEEDED(ret))
-			printf("%s:%ld:%ld:%s\n", state, (long int) i, (long int) native, text);
-	}
-	while( ret == SQL_SUCCESS );
+  do {
+    ret = SQLGetDiagRec(type, handle, ++i, state, &native, text, sizeof(text), &len );
+    if (SQL_SUCCEEDED(ret))
+      printf("%s:%ld:%ld:%s\n", state, (long int) i, (long int) native, text);
+  }
+  while( ret == SQL_SUCCESS );
 }
 
 
 Persistent<FunctionTemplate> Database::constructor_template;
 
 extern "C" void init (v8::Handle<Object> target) {
-	Database::Init(target);
+  Database::Init(target);
 }

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -241,13 +241,13 @@ int Database::EIO_AfterQuery(eio_req *req) {
 
       for(int i = 0; i < colcount; i++)
         {
-          int len;
+          SQLLEN len;
 
 	  // SQLGetData can supposedly return multiple chunks, need to do this to retrieve large fields
 
           char buf[MAX_FIELD_SIZE];
           memset(buf,0,MAX_FIELD_SIZE);
-          int ret = SQLGetData(prep_req->dbo->m_hStmt, i+1, SQL_CHAR, (char *) buf, MAX_FIELD_SIZE-1, (SQLINTEGER *) &len);
+          int ret = SQLGetData(prep_req->dbo->m_hStmt, i+1, SQL_CHAR, (char *) buf, MAX_FIELD_SIZE-1, (SQLLEN *) &len);
 
           if(ret == SQL_NULL_DATA || len < 0)
             {

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -1,17 +1,17 @@
 /*
-  Copyright (c) 2010, Lee Smith<notwink@gmail.com>
+	Copyright (c) 2010, Lee Smith<notwink@gmail.com>
 
-  Permission to use, copy, modify, and/or distribute this software for any
-  purpose with or without fee is hereby granted, provided that the above
-  copyright notice and this permission notice appear in all copies.
+	Permission to use, copy, modify, and/or distribute this software for any
+	purpose with or without fee is hereby granted, provided that the above
+	copyright notice and this permission notice appear in all copies.
 
-  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+	THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+	WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+	MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+	ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+	WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+	ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+	OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
 #include <string.h>
@@ -27,350 +27,385 @@ using namespace v8;
 using namespace node;
 
 typedef struct {
-  unsigned char *name;
-  unsigned int len;
+	unsigned char *name;
+	unsigned int len;
 } ColumnLabel;
 
 
 void Database::Init(v8::Handle<Object> target) {
-  HandleScope scope;
+	HandleScope scope;
 
-  Local<FunctionTemplate> t = FunctionTemplate::New(New);
+	Local<FunctionTemplate> t = FunctionTemplate::New(New);
 
-  constructor_template = Persistent<FunctionTemplate>::New(t);
-  constructor_template->Inherit(EventEmitter::constructor_template);
-  constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
-  constructor_template->SetClassName(String::NewSymbol("Database"));
+	constructor_template = Persistent<FunctionTemplate>::New(t);
+	constructor_template->Inherit(EventEmitter::constructor_template);
+	constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
+	constructor_template->SetClassName(String::NewSymbol("Database"));
 
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "open", Open);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "close", Close);
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "dispatchQuery", Query);
+	NODE_SET_PROTOTYPE_METHOD(constructor_template, "open", Open);
+	NODE_SET_PROTOTYPE_METHOD(constructor_template, "close", Close);
+	NODE_SET_PROTOTYPE_METHOD(constructor_template, "dispatchQuery", Query);
 
-  target->Set(v8::String::NewSymbol("Database"),
-              constructor_template->GetFunction());
+	target->Set(v8::String::NewSymbol("Database"), constructor_template->GetFunction());
 }
 
 Handle<Value> Database::New(const Arguments& args) {
-  HandleScope scope;
-  Database* dbo = new Database();
-  dbo->Wrap(args.This());
-  return args.This();
+	HandleScope scope;
+	Database* dbo = new Database();
+	dbo->Wrap(args.This());
+	return args.This();
 }
 
 int Database::EIO_AfterOpen(eio_req *req) {
-  ev_unref(EV_DEFAULT_UC);
-  HandleScope scope;
-  struct open_request *open_req = (struct open_request *)(req->data);
+	ev_unref(EV_DEFAULT_UC);
+	HandleScope scope;
+	struct open_request *open_req = (struct open_request *)(req->data);
 
-  Local<Value> argv[1];
-  bool err = false;
-  if (req->result) {
-    err = true;
-    argv[0] = Exception::Error(String::New("Error opening database"));
-  }
+	Local<Value> argv[1];
+	bool err = false;
+	if (req->result) {
+		err = true;
+		argv[0] = Exception::Error(String::New("Error opening database"));
+	}
 
-  TryCatch try_catch;
+	TryCatch try_catch;
 
-  open_req->dbo->Unref();
-  open_req->cb->Call(Context::GetCurrent()->Global(), err ? 1 : 0, argv);
+	open_req->dbo->Unref();
+	open_req->cb->Call(Context::GetCurrent()->Global(), err ? 1 : 0, argv);
 
-  if (try_catch.HasCaught()) {
-    FatalException(try_catch);
-  }
+	if (try_catch.HasCaught()) {
+		FatalException(try_catch);
+	}
 
-  open_req->dbo->Emit(String::New("ready"), 0, NULL);
-  open_req->cb.Dispose();
+	open_req->dbo->Emit(String::New("ready"), 0, NULL);
+	open_req->cb.Dispose();
 
-  free(open_req);
-  scope.Close(Undefined());
-  return 0;
+	free(open_req);
+	scope.Close(Undefined());
+	return 0;
 }
 
 int Database::EIO_Open(eio_req *req) {
-  struct open_request *open_req = (struct open_request *)(req->data);
-  Database *self = open_req->dbo->self();
+	struct open_request *open_req = (struct open_request *)(req->data);
+	Database *self = open_req->dbo->self();
 
-  int ret = SQLAllocEnv( &self->m_hEnv );
-  if( ret == SQL_SUCCESS ) {
-    ret = SQLAllocConnect( self->m_hEnv,&self->m_hDBC );
-    if( ret == SQL_SUCCESS ) {
-      SQLSetConnectOption( self->m_hDBC,SQL_LOGIN_TIMEOUT,5 );
-      char connstr[1024];
-      ret = SQLDriverConnect(self->m_hDBC,NULL,(SQLCHAR*)open_req->connection,strlen(open_req->connection),(SQLCHAR*)connstr,1024,NULL,SQL_DRIVER_NOPROMPT);
+	int ret = SQLAllocEnv( &self->m_hEnv );
+	if( ret == SQL_SUCCESS ) {
+		ret = SQLAllocConnect( self->m_hEnv,&self->m_hDBC );
+		if( ret == SQL_SUCCESS ) {
+			SQLSetConnectOption( self->m_hDBC,SQL_LOGIN_TIMEOUT,5 );
+			char connstr[1024];
+			ret = SQLDriverConnect(self->m_hDBC,NULL,(SQLCHAR*)open_req->connection,strlen(open_req->connection),(SQLCHAR*)connstr,1024,NULL,SQL_DRIVER_NOPROMPT);
 
-      if( ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO )
-        {
-          ret = SQLAllocStmt( self->m_hDBC,&self->m_hStmt );
-          if (ret != SQL_SUCCESS) printf("not connected\n");
-        }
-      else
-        {
-          self->printError("SQLDriverConnect", self->m_hDBC, SQL_HANDLE_DBC);
-        }
-    }
-  }
-  req->result = ret;
-  return 0;
+			if( ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO )
+				{
+					ret = SQLAllocStmt( self->m_hDBC,&self->m_hStmt );
+					if (ret != SQL_SUCCESS) printf("not connected\n");
+				}
+			else
+				{
+					self->printError("SQLDriverConnect", self->m_hDBC, SQL_HANDLE_DBC);
+				}
+		}
+	}
+	req->result = ret;
+	return 0;
 }
 
 Handle<Value> Database::Open(const Arguments& args) {
-  HandleScope scope;
+	HandleScope scope;
 
-  REQ_STR_ARG(0, connection);
-  REQ_FUN_ARG(1, cb);
+	REQ_STR_ARG(0, connection);
+	REQ_FUN_ARG(1, cb);
 
-  Database* dbo = ObjectWrap::Unwrap<Database>(args.This());
+	Database* dbo = ObjectWrap::Unwrap<Database>(args.This());
 
-  struct open_request *open_req = (struct open_request *)
-    calloc(1, sizeof(struct open_request) + connection.length());
+	struct open_request *open_req = (struct open_request *)
+		calloc(1, sizeof(struct open_request) + connection.length());
 
-  if (!open_req) {
-    V8::LowMemoryNotification();
-    return ThrowException(Exception::Error(
-                                           String::New("Could not allocate enough memory")));
-  }
+	if (!open_req) {
+		V8::LowMemoryNotification();
+		return ThrowException(Exception::Error(String::New("Could not allocate enough memory")));
+	}
 
-  strcpy(open_req->connection, *connection);
-  open_req->cb = Persistent<Function>::New(cb);
-  open_req->dbo = dbo;
+	strcpy(open_req->connection, *connection);
+	open_req->cb = Persistent<Function>::New(cb);
+	open_req->dbo = dbo;
 
-  eio_custom(EIO_Open, EIO_PRI_DEFAULT, EIO_AfterOpen, open_req);
+	eio_custom(EIO_Open, EIO_PRI_DEFAULT, EIO_AfterOpen, open_req);
 
-  ev_ref(EV_DEFAULT_UC);
-  dbo->Ref();
-  scope.Close(Undefined());
-  return Undefined();
+	ev_ref(EV_DEFAULT_UC);
+	dbo->Ref();
+	scope.Close(Undefined());
+	return Undefined();
 }
 
 int Database::EIO_AfterClose(eio_req *req) {
-  ev_unref(EV_DEFAULT_UC);
+	ev_unref(EV_DEFAULT_UC);
 
-  HandleScope scope;
+	HandleScope scope;
 
-  struct close_request *close_req = (struct close_request *)(req->data);
+	struct close_request *close_req = (struct close_request *)(req->data);
 
-  Local<Value> argv[1];
-  bool err = false;
-  if (req->result) {
-    err = true;
-    argv[0] = Exception::Error(String::New("Error closing database"));
-  }
+	Local<Value> argv[1];
+	bool err = false;
+	if (req->result) {
+		err = true;
+		argv[0] = Exception::Error(String::New("Error closing database"));
+	}
 
-  TryCatch try_catch;
+	TryCatch try_catch;
 
-  close_req->dbo->Unref();
-  close_req->cb->Call(Context::GetCurrent()->Global(), err ? 1 : 0, argv);
+	close_req->dbo->Unref();
+	close_req->cb->Call(Context::GetCurrent()->Global(), err ? 1 : 0, argv);
 
-  if (try_catch.HasCaught()) {
-    FatalException(try_catch);
-  }
+	if (try_catch.HasCaught()) {
+		FatalException(try_catch);
+	}
 
-  close_req->cb.Dispose();
+	close_req->cb.Dispose();
 
-  free(close_req);
-  scope.Close(Undefined());
-  return 0;
+	free(close_req);
+	scope.Close(Undefined());
+	return 0;
 }
 
 int Database::EIO_Close(eio_req *req) {
-  struct close_request *close_req = (struct close_request *)(req->data);
-  Database* dbo = close_req->dbo;
-  SQLDisconnect(dbo->m_hDBC);
-  SQLFreeHandle(SQL_HANDLE_ENV, dbo->m_hEnv);
-  SQLFreeHandle(SQL_HANDLE_DBC, dbo->m_hDBC);
-  return 0;
+	struct close_request *close_req = (struct close_request *)(req->data);
+	Database* dbo = close_req->dbo;
+	SQLDisconnect(dbo->m_hDBC);
+	SQLFreeHandle(SQL_HANDLE_ENV, dbo->m_hEnv);
+	SQLFreeHandle(SQL_HANDLE_DBC, dbo->m_hDBC);
+	return 0;
 }
 
 Handle<Value> Database::Close(const Arguments& args) {
-  HandleScope scope;
+	HandleScope scope;
 
-  REQ_FUN_ARG(0, cb);
+	REQ_FUN_ARG(0, cb);
 
-  Database* dbo = ObjectWrap::Unwrap<Database>(args.This());
+	Database* dbo = ObjectWrap::Unwrap<Database>(args.This());
 
-  struct close_request *close_req = (struct close_request *)
-    calloc(1, sizeof(struct close_request));
+	struct close_request *close_req = (struct close_request *)
+		calloc(1, sizeof(struct close_request));
 
-  if (!close_req) {
-    V8::LowMemoryNotification();
-    return ThrowException(Exception::Error(
-                                           String::New("Could not allocate enough memory")));
-  }
+	if (!close_req) {
+		V8::LowMemoryNotification();
+		return ThrowException(Exception::Error(
+																					 String::New("Could not allocate enough memory")));
+	}
 
-  close_req->cb = Persistent<Function>::New(cb);
-  close_req->dbo = dbo;
+	close_req->cb = Persistent<Function>::New(cb);
+	close_req->dbo = dbo;
 
-  eio_custom(EIO_Close, EIO_PRI_DEFAULT, EIO_AfterClose, close_req);
+	eio_custom(EIO_Close, EIO_PRI_DEFAULT, EIO_AfterClose, close_req);
 
-  ev_ref(EV_DEFAULT_UC);
-  dbo->Ref();
-  scope.Close(Undefined());
-  return Undefined();
+	ev_ref(EV_DEFAULT_UC);
+	dbo->Ref();
+	scope.Close(Undefined());
+	return Undefined();
 }
 
 int Database::EIO_AfterQuery(eio_req *req) {
-  ev_unref(EV_DEFAULT_UC);
-  struct query_request *prep_req = (struct query_request *)(req->data);
-  HandleScope scope;
+	ev_unref(EV_DEFAULT_UC);
+	struct query_request *prep_req = (struct query_request *)(req->data);
+	HandleScope scope;
 
-  // get column data
-  short colcount;
-  SQLSMALLINT buflen;
-  SQLRETURN ret;
-  SQLNumResultCols(prep_req->dbo->m_hStmt, &colcount);
+	// get column data
+	short colcount;
+	SQLSMALLINT buflen;
+	SQLRETURN ret;
+	SQLNumResultCols(prep_req->dbo->m_hStmt, &colcount);
 
-  ColumnLabel *labels = new ColumnLabel[colcount];
+	SQLLEN nColumnType;
+	SQLLEN *aColumnTypes = (SQLLEN *)malloc(sizeof(SQLLEN) * colcount);
+		
+	ColumnLabel *labels = new ColumnLabel[colcount];
 
-  // retrieve and store column names to build the row object
-  for(int i = 0; i < colcount; i++)
-    {
-      labels[i].name = new unsigned char[MAX_FIELD_SIZE];
-      memset(labels[i].name, 0, MAX_FIELD_SIZE);
-      ret = SQLColAttribute(prep_req->dbo->m_hStmt, (SQLUSMALLINT)i+1, SQL_DESC_LABEL, labels[i].name, (SQLSMALLINT)MAX_FIELD_SIZE, (SQLSMALLINT *)&buflen, NULL);
-      labels[i].len = buflen;
-    }
+	// retrieve and store column names to build the row object
+	for(int i = 0; i < colcount; i++)
+	{
+		labels[i].name = new unsigned char[MAX_FIELD_SIZE];
+		memset(labels[i].name, 0, MAX_FIELD_SIZE);
+		ret = SQLColAttribute(prep_req->dbo->m_hStmt, (SQLUSMALLINT)i+1, SQL_DESC_LABEL, labels[i].name, (SQLSMALLINT)MAX_FIELD_SIZE, (SQLSMALLINT *)&buflen, NULL);
+		labels[i].len = buflen;
+		
+		//get the column type
+		ret = SQLColAttribute( prep_req->dbo->m_hStmt, (SQLUSMALLINT)i+1, SQL_COLUMN_TYPE, NULL, NULL, NULL, &aColumnTypes[ i ] );
+		
+	}
 
-  // i dont think odbc will tell how many rows are returned, loop until out...
-  Local<Array> rows = Array::New();
-  int count = 0;
-  while(true)
-    {
-      Local<Object> tuple = Object::New();
-      ret = SQLFetch(prep_req->dbo->m_hStmt);
-      if(ret) break; // error :|
+	// i dont think odbc will tell how many rows are returned, loop until out...
+	Local<Array> rows = Array::New();
+	int count = 0;
+	while(true)
+	{
+		Local<Object> tuple = Object::New();
+		ret = SQLFetch(prep_req->dbo->m_hStmt);
+		if(ret) break; // error :|
 
-      for(int i = 0; i < colcount; i++)
-        {
-          SQLLEN len;
+		for(int i = 0; i < colcount; i++)
+		{
+			SQLLEN len;
+			
+			//get the column type;
+			nColumnType = aColumnTypes[i];
+			
+			// SQLGetData can supposedly return multiple chunks, need to do this to retrieve large fields
 
-	  // SQLGetData can supposedly return multiple chunks, need to do this to retrieve large fields
+			char buf[MAX_FIELD_SIZE];
+			memset(buf,0,MAX_FIELD_SIZE);
+			int ret = SQLGetData(prep_req->dbo->m_hStmt, i+1, SQL_CHAR, (char *) buf, MAX_FIELD_SIZE-1, (SQLLEN *) &len);
 
-          char buf[MAX_FIELD_SIZE];
-          memset(buf,0,MAX_FIELD_SIZE);
-          int ret = SQLGetData(prep_req->dbo->m_hStmt, i+1, SQL_CHAR, (char *) buf, MAX_FIELD_SIZE-1, (SQLLEN *) &len);
+			if(ret == SQL_NULL_DATA || len < 0)
+			{
+				tuple->Set(String::New((const char *)labels[i].name), Null());
+			}
+			else
+			{ 
+				switch (nColumnType) {
+					case SQL_NUMERIC :
+						tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
+						break;
+					case SQL_DECIMAL :
+						tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
+						break;
+					case SQL_INTEGER :
+						tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
+						break;
+					case SQL_SMALLINT :
+						tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
+						break;
+					case SQL_FLOAT :
+						tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
+						break;
+					case SQL_REAL :
+						tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
+						break;
+					case SQL_DOUBLE :
+						tuple->Set(String::New((const char *)labels[i].name), Number::New(atof(buf)));
+						break;
+					default :
+						tuple->Set(String::New((const char *)labels[i].name), String::New(buf));
+						break;
+				}
+			}
+		}
+		rows->Set(Integer::New(count), tuple);
+		count++;
+	}
 
-          if(ret == SQL_NULL_DATA || len < 0)
-            {
-              tuple->Set(String::New((const char *)labels[i].name), Null());
-            }
-          else
-            {
-              tuple->Set(String::New((const char *)labels[i].name), String::New(buf));
-            }
-        }
-      rows->Set(Integer::New(count), tuple);
-      count++;
-    }
+	for(int i = 0; i < colcount; i++)
+	{
+		delete [] labels[i].name;
+	}
+	
+	delete [] labels;
 
-  for(int i = 0; i < colcount; i++)
-    {
-      delete [] labels[i].name;
-    }
-  delete [] labels;
+	TryCatch try_catch;
 
-  TryCatch try_catch;
+	prep_req->dbo->Unref();
 
-  prep_req->dbo->Unref();
+	if (try_catch.HasCaught()) {
+		FatalException(try_catch);
+	}
 
-  if (try_catch.HasCaught()) {
-    FatalException(try_catch);
-  }
-
-  SQLFreeStmt(prep_req->dbo->m_hStmt,NULL);
-  SQLAllocStmt(prep_req->dbo->m_hDBC,&prep_req->dbo->m_hStmt );
+	SQLFreeStmt(prep_req->dbo->m_hStmt,NULL);
+	SQLAllocStmt(prep_req->dbo->m_hDBC,&prep_req->dbo->m_hStmt );
 
 
-  Local<Value> args[2];
-  args[0] = Local<Value>::New(Null());
-  args[1] = rows;
+	Local<Value> args[2];
+	args[0] = Local<Value>::New(Null());
+	args[1] = rows;
 
-  prep_req->dbo->Emit(String::New("result"), 2, args);
+	prep_req->dbo->Emit(String::New("result"), 2, args);
 
-  free(prep_req);
-  scope.Close(Undefined());
-  return 0;
+	free(aColumnTypes);
+	free(prep_req);
+	scope.Close(Undefined());
+	
+	
+	return 0;
 }
 
 int Database::EIO_Query(eio_req *req) {
-  struct query_request *prep_req = (struct query_request *)(req->data);
+	struct query_request *prep_req = (struct query_request *)(req->data);
 
 
-  if(prep_req->dbo->m_hStmt)
-    {
-      SQLFreeStmt(prep_req->dbo->m_hStmt,NULL);
-      SQLAllocStmt(prep_req->dbo->m_hDBC,&prep_req->dbo->m_hStmt );
-    }
+	if(prep_req->dbo->m_hStmt)
+		{
+			SQLFreeStmt(prep_req->dbo->m_hStmt,NULL);
+			SQLAllocStmt(prep_req->dbo->m_hDBC,&prep_req->dbo->m_hStmt );
+		}
 
-  SQLRETURN ret = SQLExecDirect( prep_req->dbo->m_hStmt,(SQLCHAR *)prep_req->sql, strlen(prep_req->sql) );
-  if(ret != 0)
-    {
-      char buf[512];
-      char sqlstate[128];
-      SQLError(prep_req->dbo->m_hEnv, prep_req->dbo->m_hDBC, prep_req->dbo->m_hStmt,(SQLCHAR *)sqlstate,NULL,(SQLCHAR *)buf, sizeof(buf), NULL);
-    }
+	SQLRETURN ret = SQLExecDirect( prep_req->dbo->m_hStmt,(SQLCHAR *)prep_req->sql, strlen(prep_req->sql) );
+	if(ret != 0)
+		{
+			char buf[512];
+			char sqlstate[128];
+			SQLError(prep_req->dbo->m_hEnv, prep_req->dbo->m_hDBC, prep_req->dbo->m_hStmt,(SQLCHAR *)sqlstate,NULL,(SQLCHAR *)buf, sizeof(buf), NULL);
+		}
 
-  req->result = ret;
+	req->result = ret;
 
-  return 0;
+	return 0;
 }
 
 Handle<Value> Database::Query(const Arguments& args) {
-  HandleScope scope;
+	HandleScope scope;
 
-  REQ_STR_ARG(0, sql);
-  //REQ_FUN_ARG(1, cb);
+	REQ_STR_ARG(0, sql);
+	//REQ_FUN_ARG(1, cb);
 
-  Database* dbo = ObjectWrap::Unwrap<Database>(args.This());
+	Database* dbo = ObjectWrap::Unwrap<Database>(args.This());
 
-  struct query_request *prep_req = (struct query_request *)
-    calloc(1, sizeof(struct query_request) + sql.length());
+	struct query_request *prep_req = (struct query_request *)
+		calloc(1, sizeof(struct query_request) + sql.length());
 
-  if (!prep_req) {
-    V8::LowMemoryNotification();
-    return ThrowException(Exception::Error(
-                                           String::New("Could not allocate enough memory")));
-  }
+	if (!prep_req) {
+		V8::LowMemoryNotification();
+		return ThrowException(Exception::Error(String::New("Could not allocate enough memory")));
+	}
 
-  strcpy(prep_req->sql, *sql);
+	strcpy(prep_req->sql, *sql);
 
-  prep_req->dbo = dbo;
+	prep_req->dbo = dbo;
 
-  eio_custom(EIO_Query, EIO_PRI_DEFAULT, EIO_AfterQuery, prep_req);
+	eio_custom(EIO_Query, EIO_PRI_DEFAULT, EIO_AfterQuery, prep_req);
 
-  ev_ref(EV_DEFAULT_UC);
-  dbo->Ref();
-  scope.Close(Undefined());
-  return Undefined();
+	ev_ref(EV_DEFAULT_UC);
+	dbo->Ref();
+	scope.Close(Undefined());
+	return Undefined();
 }
 
 void Database::printError(const char *fn, SQLHANDLE handle, SQLSMALLINT type)
 {
-  SQLINTEGER i = 0;
-  SQLINTEGER native;
-  SQLCHAR state[ 7 ];
-  SQLCHAR text[256];
-  SQLSMALLINT len;
-  SQLRETURN ret;
+	SQLINTEGER i = 0;
+	SQLINTEGER native;
+	SQLCHAR state[ 7 ];
+	SQLCHAR text[256];
+	SQLSMALLINT len;
+	SQLRETURN ret;
 
-  fprintf(stderr,
-          "\n"
-          "The driver reported the following diagnostics whilst running "
-          "%s\n\n",
-          fn);
+	fprintf(stderr,
+		"\n"
+		"The driver reported the following diagnostics whilst running "
+		"%s\n\n",
+		fn
+	);
 
-  do
-    {
-      ret = SQLGetDiagRec(type, handle, ++i, state, &native, text,
-                          sizeof(text), &len );
-      if (SQL_SUCCEEDED(ret))
-        printf("%s:%ld:%ld:%s\n", state, i, native, text);
-    }
-  while( ret == SQL_SUCCESS );
+	do {
+		ret = SQLGetDiagRec(type, handle, ++i, state, &native, text, sizeof(text), &len );
+		if (SQL_SUCCEEDED(ret))
+			printf("%s:%ld:%ld:%s\n", state, (long int) i, (long int) native, text);
+	}
+	while( ret == SQL_SUCCESS );
 }
 
 
 Persistent<FunctionTemplate> Database::constructor_template;
 
 extern "C" void init (v8::Handle<Object> target) {
-  Database::Init(target);
+	Database::Init(target);
 }

--- a/src/Database.h
+++ b/src/Database.h
@@ -62,6 +62,7 @@ class Database : public EventEmitter {
   HENV m_hEnv;
   HDBC m_hDBC;
   HSTMT m_hStmt;
+  SQLUSMALLINT hasMoreResults;
 };
 
 enum ExecMode

--- a/src/Database.h
+++ b/src/Database.h
@@ -62,7 +62,7 @@ class Database : public EventEmitter {
   HENV m_hEnv;
   HDBC m_hDBC;
   HSTMT m_hStmt;
-  SQLUSMALLINT hasMoreResults;
+  SQLUSMALLINT canHaveMoreResults;
 };
 
 enum ExecMode


### PR DESCRIPTION
Here are some changes including pushing the correct data type into the result set and handling multiple result sets. By multiple result sets I mean when you call the query function passing a string which includes multiple SQL statements, emit('result') will be called for the result of each one.

Example:

<pre>
db.query([
 "Select top 10 * from customer;",
 "Select top 10 * from orders;",
 "Select top 10 * from users;"
].join('\n'), function (err, data, moreResultSets) {
   console.log(data);
});
</pre>


Will cause the callback function to be called three times. The first two times moreResultSets will be true and the last time it will be false.

This also fixes a bug where if the first couple select statements don't return any columns you can get the results from statements that do.

Example:

<pre>
db.query([
 "declare @num int;",
 "select @num = count(*) from users;", //this previously would have resulted in an emit
 "Select top 10 @num as totalUsers, * from users;" //this previously would have not been returned at all.
].join('\n'), function (err, data, moreResultSets) {
   console.log(data);
});
</pre>

In this case the call back function is now called only once when there is a statement that actually returns a result set that contains columns.

I would like some feedback on the data type handling. I'm not sure if I like the casting to Date(). It doesn't seem to be very helpful on the javascript side. Wondering if it would just be better to return it as a string.

Thanks!!

Dan
