### PR TITLE
Recent changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,23 @@ DESCRIPTION
 
 unixODBC binding to node. Needs a properly configured odbc(inst).ini.  Tested locally using the FreeTDS and Postgres drivers.
 
-Installation
+
+INSTALLATION
 ------------
 
-- Make sure you have unixODBC installed and the drivers configured.
+- Make sure you have the unixODBC binaries and unixODBC headers installed and the drivers configured.
+	- On ubuntu and probably most linux distros the unixODBC header files are in the unixodbc-dev package (apt-get install unixodbc-dev)
 - node-waf configure build
+
+
 
 TIPS
 ----
 
 - If you are using the FreeTDS ODBC driver and you have column names longer than 30 characters, you should add "TDS_Version=7.0" to your connection string to retrive the full column name.
-  Example: "DRIVER={FreeTDS};SERVER=host;UID=user;PWD=password;DATABASE=dbname;TDS_Version=7.0"
+  Example: 
+
+	"DRIVER={FreeTDS};SERVER=host;UID=user;PWD=password;DATABASE=dbname;TDS_Version=7.0"
 
 
 BUGS
@@ -47,8 +53,10 @@ None known, but there might be one ;).
 TODO
 ----
 
-- Not complete, supports connection management and querying.
-- Better (any?) error handling.
+- Not complete; supports connection management, querying and database descriptions
+- Binding parameters (SQLBindParameter)?
+- Option to emit on each record to avoid collecting the entire dataset first and increasing memory usage
+- More error handling.
 - Tests
 - SQLGetData needs to support retrieving multiple chunks and concatenation in the case of large	column values
 

--- a/examples/describe.js
+++ b/examples/describe.js
@@ -1,0 +1,109 @@
+/* 
+ * This example discusses the use of the odbc describe method.
+ * 
+ */
+
+var odbc = require("../odbc.js"),
+      db = new odbc.Database();
+
+      
+//open a connection to the database
+db.open("DSN=myDsnName;UID=myUserName;PWD=mySuperSecretPassword;DATABASE=myAwesomeDatabase", function(err)
+{
+	
+	if (err) {
+		//Something went bad
+		console.log(err);
+		
+		//Let's not go any further
+		return;
+	}
+	
+	/*
+	 * In its most basic form you must call describe passing it an object which 
+	 * contains the database name and a callback function.
+	 * 
+	 * This will return a list of tables in the database for all schemas.
+	 */
+	
+	db.describe({
+		database : 'myAwesomeDatabase'
+	}, function (error, result) {
+		if (error) {
+			console.log(error);
+			return false;
+		}
+		
+		console.log(result);
+	});
+	
+	/*
+	 * Sometimes there may be schemas that you don't want to see, on MSSQL, sys comes to mind
+	 * 
+	 * So you can specify which schema you are looking for by specifying the schema property.
+	 */
+	
+	db.describe({
+		database : 'myAwesomeDatabase',
+		schema : 'dbo'
+	}, function (error, result) {
+		if (error) {
+			console.log(error);
+			return false;
+		}
+		
+		console.log(result);
+	});
+	
+	/*
+	 * Or you can get a list of views by specifying the type property
+	 */
+	
+	db.describe({
+		database : 'myAwesomeDatabase',
+		schema : 'dbo',
+		type : 'view'
+	}, function (error, result) {
+		if (error) {
+			console.log(error);
+			return false;
+		}
+		
+		console.log(result);
+	});
+	
+	/*
+	 * You can get a list of columns in a table by specifying the table property
+	 */
+	
+	db.describe({
+		database : 'myAwesomeDatabase',
+		schema : 'dbo',
+		table : 'customers'
+	}, function (error, result) {
+		if (error) {
+			console.log(error);
+			return false;
+		}
+		
+		console.log(result);
+	});
+	
+	/*
+	 * Or you can get information on a specific column in a specific table by also specifying the column property
+	 */
+	
+	db.describe({
+		database : 'myAwesomeDatabase',
+		schema : 'dbo',
+		table : 'customers',
+		column : 'name'
+	}, function (error, result) {
+		if (error) {
+			console.log(error);
+			return false;
+		}
+		
+		console.log(result);
+	});
+});

--- a/odbc.js
+++ b/odbc.js
@@ -18,59 +18,97 @@ var sys = require("sys");
 var odbc = require("./odbc_bindings");
 
 var Database = exports.Database = function () {
-    var self = this;
-    var db = new odbc.Database();
-
-    db.__proto__ = Database.prototype;
-
-    db.addListener("ready", function () {
-        db.maybeDispatchQuery();
-    });
-
-    db.addListener("result", function () {
-        //process.assert(db.currentQuery).ok();
-        require('assert').ok(db.currentQuery);
-        
-        var callback = db.currentQuery[1];
-        var args = Array.prototype.slice.call(db.currentQuery[2]);
-        args.shift();
-        args.shift();
-
-        //check to see if this is the last result set returned
-        if (!arguments[2]) {
-            db.currentQuery = null;
-        }
-        
-        if (callback) {
-            var newArgs = Array.prototype.slice.call(arguments);
-
-            for(var i = 0; i < args.length; i++) {
-                newArgs.push(args[i]);
-            }
-
-            callback.apply(db, newArgs);
-        }
-        db.maybeDispatchQuery();
-    });
-
-    return db;
+  var self = this;
+  var db = new odbc.Database();
+  db.executing = false;
+  db.queue = [];
+  
+  db.__proto__ = Database.prototype;
+  
+  db.addListener("ready", function () {
+    self.processQueue();
+  });
+  
+  db.addListener("result", function () {
+    var currentQuery = this.queue[0];
+    
+    require('assert').ok(currentQuery);
+    
+    var callback = currentQuery.callback;
+    
+    var args = Array.prototype.slice.call(currentQuery.args);
+    args.shift(); //this is wrong for SQLTables
+    args.shift(); //this is wrong for SQLTables
+    
+    //check to see if this is the last result set returned
+    if (!arguments[2]) {
+      this.queue.shift();
+      this.executing = false;
+    }
+    
+    if (callback) {
+      var newArgs = Array.prototype.slice.call(arguments);
+      
+      for(var i = 0; i < args.length; i++) {
+        newArgs.push(args[i]);
+      }
+      
+      callback.apply(db, newArgs);
+    }
+    
+    db.processQueue();
+  });
+  
+  return db;
 };
 
 Database.prototype = {
-    __proto__: odbc.Database.prototype,
-    constructor: Database,
+  __proto__: odbc.Database.prototype,
+  constructor: Database,
 };
 
-Database.prototype.maybeDispatchQuery = function () {
-    if (!this._queries) return;
-    if (!this.currentQuery && this._queries.length > 0) {
-        this.currentQuery = this._queries.shift();
-        this.dispatchQuery(this.currentQuery[0]);
-    }
+Database.prototype.processQueue = function () {
+  var self = this;
+  
+  if (!self.queue) self.queue = [];
+  
+  if (!self.executing && self.queue.length) {
+    var currentQuery = self.queue[0];
+    self.executing = true;
+    
+    currentQuery.method.apply(currentQuery.context, currentQuery.args); //TODO: we need to make sure we aren't sending any extra arguments to the cpp method
+  }
 };
 
 Database.prototype.query = function(sql, callback) {
-    this._queries = this._queries || [];
-    this._queries.push([sql, callback, arguments]);
-    this.maybeDispatchQuery();
+  var self = this;
+  if (!self.queue) self.queue = [];
+  
+  self.queue.push({
+    context : self,
+    method : self.dispatchQuery,
+    sql : sql, 
+    callback : callback, 
+    args : arguments
+  });
+  
+  self.processQueue();
 };
+
+Database.prototype.tables = function(catalog, schema, table, type, callback) {
+  var self = this;
+  if (!self.queue) self.queue = [];
+  
+  self.queue.push({
+    context : self,
+    method : self.dispatchTables,
+    catalog : (arguments.length > 1) ? catalog : "",
+    schema : (arguments.length > 2) ? schema : "",
+    table : (arguments.length > 3) ? table : "",
+    type : (arguments.length > 4) ? type : "",
+    callback : (arguments.length == 5) ? callback : arguments[arguments.lengt - 1],
+    args : arguments
+  });
+  
+  self.processQueue();
+}

--- a/odbc.js
+++ b/odbc.js
@@ -36,11 +36,6 @@ var Database = exports.Database = function () {
         args.shift();
         args.shift();
 
-        if(arguments[0])
-        {
-            arguments[0].query = db.currentQuery[0];
-        }
-        
         //check to see if this is the last result set returned
         if (!arguments[2]) {
             db.currentQuery = null;

--- a/src/Database.h
+++ b/src/Database.h
@@ -55,6 +55,10 @@ class Database : public EventEmitter {
   static int EIO_Query(eio_req *req);
   static Handle<Value> Query(const Arguments& args);
 
+  static int EIO_Tables(eio_req *req);
+  static Handle<Value> Tables(const Arguments& args);
+
+  
   Database *self(void) { return this; }
   void printError(const char *fn, SQLHANDLE handle, SQLSMALLINT type);
 
@@ -87,7 +91,11 @@ struct query_request {
   Persistent<Function> cb;
   Database *dbo;
   int affectedRows;
-  char sql[1];
+  char *sql;
+  char *catalog;
+  char *schema;
+  char *table;
+  char *type;
 };
 
 #define REQ_ARGS(N)                                                     \
@@ -99,6 +107,12 @@ struct query_request {
   if (args.Length() <= (I) || !args[I]->IsString())                     \
     return ThrowException(Exception::TypeError(                         \
                                                String::New("Argument " #I " must be a string"))); \
+  String::Utf8Value VAR(args[I]->ToString());
+
+#define REQ_STR_OR_NULL_ARG(I, VAR)                                             \
+  if ( args.Length() <= (I) || (!args[I]->IsString() && !args[I]->IsNull()) )                     \
+    return ThrowException(Exception::TypeError(                         \
+                                               String::New("Argument " #I " must be a string or null"))); \
   String::Utf8Value VAR(args[I]->ToString());
 
 #define REQ_FUN_ARG(I, VAR)                                             \

--- a/src/Database.h
+++ b/src/Database.h
@@ -58,6 +58,8 @@ class Database : public EventEmitter {
   static int EIO_Tables(eio_req *req);
   static Handle<Value> Tables(const Arguments& args);
 
+  static int EIO_Columns(eio_req *req);
+  static Handle<Value> Columns(const Arguments& args);
   
   Database *self(void) { return this; }
   void printError(const char *fn, SQLHANDLE handle, SQLSMALLINT type);
@@ -96,6 +98,7 @@ struct query_request {
   char *schema;
   char *table;
   char *type;
+  char *column;
 };
 
 #define REQ_ARGS(N)                                                     \


### PR DESCRIPTION
I have included some bug fixes, better error handling including a global 'error' emitter. Also there is a tables method which passes values to the SQLTables function. The values that need to be passed to that function, quite odd in my opinion, are described here:

From: http://msdn.microsoft.com/en-us/library/ms711831(v=vs.85).aspx

```
To support enumeration of catalogs, schemas, and table types, the following special semantics are defined for the CatalogName, SchemaName, TableName, and TableType arguments of SQLTables:

If CatalogName is SQL_ALL_CATALOGS and SchemaName and TableName are empty strings, the result set contains a list of valid catalogs for the data source. (All columns except the TABLE_CAT column contain NULLs.)

If SchemaName is SQL_ALL_SCHEMAS and CatalogName and TableName are empty strings, the result set contains a list of valid schemas for the data source. (All columns except the TABLE_SCHEM column contain NULLs.)

If TableType is SQL_ALL_TABLE_TYPES and CatalogName, SchemaName, and TableName are empty strings, the result set contains a list of valid table types for the data source. (All columns except the TABLE_TYPE column contain NULLs.)

If TableType is not an empty string, it must contain a list of comma-separated values for the types of interest; each value can be enclosed in single quotation marks (') or unquoted, for example, 'TABLE', 'VIEW' or TABLE, VIEW. An application should always specify the table type in uppercase; the driver should convert the table type to whatever case is needed by the data source. If the data source does not support a specified table type, SQLTables does not return any results for that type.
```
