### PR TITLE
Fixes and features

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+module.exports = require('./odbc.js');
+

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -268,7 +268,8 @@ int Database::EIO_AfterQuery(eio_req *req) {
       char errorSQLState[128];
       SQLError(self->m_hEnv, self->m_hDBC, self->m_hStmt,(SQLCHAR *)errorSQLState,NULL,(SQLCHAR *)errorMessage, sizeof(errorMessage), NULL);
       objError->Set(String::New("state"), String::New(errorSQLState));
-      objError->Set(String::New("error"), String::New(errorMessage));
+      objError->Set(String::New("error"), String::New("[node-odbc] SQL_ERROR"));
+      objError->Set(String::New("message"), String::New(errorMessage));
       
       //only set the query value of the object if we actually have a query
       if (prep_req->sql != NULL) {
@@ -336,7 +337,8 @@ int Database::EIO_AfterQuery(eio_req *req) {
             
             errorCount++;
             objError->Set(String::New("state"), String::New(errorSQLState));
-            objError->Set(String::New("error"), String::New(errorMessage));
+	    objError->Set(String::New("error"), String::New("[node-odbc] SQL_ERROR"));
+            objError->Set(String::New("message"), String::New(errorMessage));
             objError->Set(String::New("query"), String::New(prep_req->sql));
             
             //emit an error event immidiately.

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -45,7 +45,7 @@ void Database::Init(v8::Handle<Object> target) {
   constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
   constructor_template->SetClassName(String::NewSymbol("Database"));
 
-  NODE_SET_PROTOTYPE_METHOD(constructor_template, "open", Open);
+  NODE_SET_PROTOTYPE_METHOD(constructor_template, "dispatchOpen", Open);
   NODE_SET_PROTOTYPE_METHOD(constructor_template, "dispatchClose", Close);
   NODE_SET_PROTOTYPE_METHOD(constructor_template, "dispatchQuery", Query);
   NODE_SET_PROTOTYPE_METHOD(constructor_template, "dispatchTables", Tables);


### PR DESCRIPTION
- This pull request fixes issue #6
- Fixes an unreported bug which caused segfaults when calling close() while query was running
- Added index.js file
- A simple connection pool; used like:
  
  ```
  var pool = new odbc.Pool();
  
  pool.open('connection string goes here', function (err, connection) {
      //we have a connection
  
      connection.query('select * from users', function (err, results, moreResults) {
          console.log(results);
  
          connection.close(function () {
              //connection closed
          });
      });
  });
  ```

When you close the connection, it closes that connection but then re-opens it and adds it to the pool (this clears any temp tables, at least on MSSQL). Next time you request to open a connection with the same connection string it will be waiting for you, already open. On my system, this saves about 5ms per open() call.
