### PR TITLE
added parameter binding

### DIFF
--- a/examples/params.js
+++ b/examples/params.js
@@ -1,0 +1,45 @@
+/*
+ * This example demonstrates odbc parameter binding.
+ *
+ */
+
+var odbc = require("../odbc.js"),
+      db = new odbc.Database();
+
+
+
+//open a connection to the database
+db.open("DSN=myDsnName;UID=myUserName;PWD=mySuperSecretPassword;DATABASE=myAwesomeDatabase;CHARSET=UTF8", function(err)
+{
+
+    if (err) {
+        //Something went bad
+        console.log(err);
+
+        //Let's not go any further
+        return;
+    }
+
+    /*
+     * A quick example of passing some random parameters
+     *
+     */
+    
+    db.query("select ? as a, ? as b, ? as c, ? as d, ? as e", [null, 4711, true, -3.14, 'string'], function (error, result, info) {
+        console.log("some random parameters");
+        if (error) {console.log(error); return false;}
+        console.log(result);
+    });
+    
+    /*
+     * Some non-ASCII-characters (note that db.open above is configured to use utf8 encoding) 
+     *
+     */
+    
+    db.query("select ?", ['áäàéêèóöòüßÄÖÜ€'], function (error, result) {
+        console.log("some non-ASCII characters");
+        if (error) {console.log(error); return false;} 
+        console.log(result);
+    });
+
+});

--- a/odbc.js
+++ b/odbc.js
@@ -81,8 +81,10 @@ Database.prototype.processQueue = function () {
   }
 };
 
-Database.prototype.query = function(sql, callback) {
+Database.prototype.query = function(sql, params, callback) {
   var self = this;
+
+  if (callback == null) callback = params; // no parameters supplied
   
   if (!self.connected) {
     return callback( { message : "Connection not open." }, [], false );

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -500,7 +500,7 @@ int Database::EIO_Query(eio_req *req) {
   // prepare statement, bind parameters and execute statement 
   //
   SQLRETURN ret = SQLPrepare(prep_req->dbo->m_hStmt, (SQLCHAR *)prep_req->sql, strlen(prep_req->sql));
-  if (ret == SQL_SUCCESS || SQL_SUCCESS_WITH_INFO) 
+  if (ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO) 
   {
       for (int i = 0; i < prep_req->paramCount; i++) 
       {
@@ -510,7 +510,7 @@ int Database::EIO_Query(eio_req *req) {
           if (ret == SQL_ERROR) {break;}
       }
 
-      if (ret == SQL_SUCCESS || SQL_SUCCESS_WITH_INFO) {
+      if (ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO) {
           ret = SQLExecute(prep_req->dbo->m_hStmt);
       }
   }

--- a/src/Database.h
+++ b/src/Database.h
@@ -91,6 +91,15 @@ struct close_request {
   Database *dbo;
 };
 
+typedef struct {
+    SQLSMALLINT  c_type;
+    SQLSMALLINT  type;
+    SQLLEN       size;
+    void        *buffer;
+    SQLLEN       buffer_length;    
+    SQLLEN       length;
+} Parameter;
+
 struct query_request {
   Persistent<Function> cb;
   Database *dbo;
@@ -101,6 +110,8 @@ struct query_request {
   char *table;
   char *type;
   char *column;
+  Parameter *params;
+  int  paramCount;
 };
 
 #define REQ_ARGS(N)                                                     \


### PR DESCRIPTION
Replaced SQLExecDirect with SQLPrepare, SQLBindParameter and SQLExecute,
changed Database.query() to take an optional array of parameter values
as its second argument.
