### PR TITLE
Binding Parameters Bug Fix and Version Bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "odbc",
   "description": "unixodbc bindings for node",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "homepage": "http://github.com/w1nk/node-odbc/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Fix binding-params queries and only use them when needed
- [binding-params] Accept optional params array as an argument to the query method
- [binding-params] Bypass binding parameters and use SQLExecDirect if there is no params array

The original pull request for binding params seems to have missed some critical parts. This
commit fixes these shortcomings. The issues were:
- odbc.js's query method was modified to accept a `params` array, but this array was not passed on to the cpp side of things
- Database.ccp was modified to populate prep_req->params if arg[1] was an array, but it was never an array because it wasn't passed from javascript land.
- SQLPrepare and SQLExecute were always used even when there was no need to if no   parameter array was passed.

---

I have also bumped the version to v0.3.1 which should be inline for the next npm release.
