### PR TITLE
Prevent build failures caused by node v4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lib": "."
   },
   "engines": {
-    "node": "*"
+    "node": "<4.0.0"
   },
   "scripts": { 
     "preinstall":"node-waf configure build"


### PR DESCRIPTION
Fixes #94, by giving the developer an accurate error and prevents `node-gyp` from trying to build a project that does not support `node v4.x` yet.

The patch version should be bumped and the new version should be published to `npm`.
